### PR TITLE
Fix to read merge commits in diff-tree command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Click Save & queue > Save and run.
 
 ## Executing Git to Code Pipeline Sync
 
+**Pre-requisite:** Disable shallow fetch in Azure Pipeline. [Click here for more information.](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#sync-tags)
+
 This Git to Code Pipeline Sync task has following parameters:
 
 -   **Display name** :  The name of the Task.

--- a/azure-deveops-ispw-operation-task/actions/sync/git-command-helper.ts
+++ b/azure-deveops-ispw-operation-task/actions/sync/git-command-helper.ts
@@ -26,7 +26,7 @@ export async function calculateDiff(
   
   //arg to find changed files name only
   if (commitid) {
-    args = ["diff-tree", "--no-commit-id", "--name-only", "-r", commitid];
+    args = ["diff-tree", "--no-commit-id", "--name-only", "-m", "-r", commitid];
   } else {
     throw new Error("Commit id is not found!");
   }

--- a/azure-deveops-ispw-operation-task/task.json
+++ b/azure-deveops-ispw-operation-task/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 2,
-    "Patch": 1
+    "Patch": 2
   },
   "instanceNameFormat": "Code Pipeline Operations",
   "groups": [

--- a/azure-deveops-ispw-operation-task/task.json
+++ b/azure-deveops-ispw-operation-task/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 2,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "Code Pipeline Operations",
   "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "id": "ispw-operations",
     "name": "BMC AMI DevX Code Pipeline Operations",
     "public": true,
-    "version": "2.2.0",
+    "version": "2.2.1",
     "publisher": "BMC",
     "targets": [
         {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "id": "ispw-operations",
     "name": "BMC AMI DevX Code Pipeline Operations",
     "public": true,
-    "version": "2.2.1",
+    "version": "2.2.2",
     "publisher": "BMC",
     "targets": [
         {


### PR DESCRIPTION
Diff-tree command doesnot identify files changed as a result of a merge commit. To fix this we add a -m flag to the command.